### PR TITLE
Simplify devcontainer

### DIFF
--- a/.devcontainer/DockerFile
+++ b/.devcontainer/DockerFile
@@ -1,2 +1,0 @@
-FROM ludeeus/devcontainer:base
-RUN apk add nodejs npm

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,23 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
 	"name": "Custom Header Development",
-	"dockerFile": "DockerFile",
+	"image": "ludeeus/devcontainer:frontend-stable",
 	"context": "..",
 	"appPort": [
 		"5000:5000"
 	],
 	"postCreateCommand": "npm install",
 	"runArgs": [
-		"-v",
-		"${env:HOME}${env:USERPROFILE}/.ssh:/tmp/.ssh" // This is added so you can push from inside the container
+		"-v", "${env:HOME}${env:USERPROFILE}/.ssh:/tmp/.ssh" // This is added so you can push from inside the container
 	],
 	"extensions": [
 		"github.vscode-pull-request-github",
-		"tabnine.tabnine-vscode"
+		"tabnine.tabnine-vscode",
+		"dbaeumer.vscode-eslint",
+		"ms-vscode.vscode-typescript-tslint-plugin",
+		"esbenp.prettier-vscode",
+		"bierner.lit-html",
+		"runem.lit-plugin"
 	],
 	"settings": {
 		"files.eol": "\n",


### PR DESCRIPTION
- Change from `ludeeus/devcontainer:base` to `ludeeus/devcontainer:frontend-stable` 
  - This has node, npm and yarn in addition to the base image preinstalled which means that startup times are faster 🐎 
  - It also uses the `-stable` variant of the tags which is .safer.
- Removes a now unneeded file