### PR TITLE
fix date example

### DIFF
--- a/docs/templates/examples.md
+++ b/docs/templates/examples.md
@@ -33,5 +33,5 @@ This will make the menu button display the date like this `Wed. Dec. 25 2019`.
 ```yaml
 custom_header:
   button_text:
-    menu: '{{ dayNameShort }}. {{ monthNameShort }}. {{ monthNum }} {{ year4d }}'
+    menu: '{{ dayNameShort }}. {{ monthNameShort }}. {{ dayNum }} {{ year4d }}'
 ```


### PR DESCRIPTION
{{ monthnum }} would have made the example show Wed. Dec. 12 2019, thus using the month twice and no date.