### PR TITLE
removed resources in yaml example instructions

### DIFF
--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -9,13 +9,10 @@ Much of the config can be done by using the UI editor which can be found by sele
 
 Everything else is handled in YAML which would either be set in the raw config by selecting "Configure UI" and then "Raw Config Editor" or in the file `ui-lovelace.yaml` if you're using YAML mode.
 
-The YAML configuration happens at the root of your Lovelace config under `custom_header:` at the same level as `resources:` and `views:`. Example:
+The YAML configuration happens at the root of your Lovelace config under `custom_header:` at the same level as `views:`. Example:
 
 ```yaml
 custom_header:
   compact_mode: true
-resources:
-  - url: /community_plugin/custom-header/custom-header.js
-    type: module
 views:
 ```


### PR DESCRIPTION
Removed mention of `resources:` being in ui-lovelace.yaml or raw config. This can cause confusion to new users as the location of resources has changed